### PR TITLE
Fixed ODBC Driver name that is to be used.

### DIFF
--- a/sqlalchemy_exasol/pyodbc.py
+++ b/sqlalchemy_exasol/pyodbc.py
@@ -17,7 +17,7 @@ class EXADialect_pyodbc(EXADialect, PyODBCConnector):
 
     execution_ctx_cls = EXAExecutionContext
 
-    pyodbc_driver_name = "EXAODBC"
+    pyodbc_driver_name = "EXASolution Driver"
     driver_version = None
     server_version_info = None
 


### PR DESCRIPTION
Colleague ran into an issue using the exasol dialect under windows. 

When using a DSN to connect to the database, everything worked without a problem. In the case of my colleague they needed to work based on a connection string instead and in this case the code is using the wrong name for the driver and you end up with ODBC im002 errors indicating that driver was not found and no default was provided.

The ODBC Administrator window showing the name of the driver that is to be used in connection strings:
![image](https://cloud.githubusercontent.com/assets/2786853/24901012/0b64228e-1ea6-11e7-8667-d1c2d412032e.png)


The provided patch resolves this issue.


