### PR TITLE
upgrade pyodbc,turbodbc and make deprecation warnings in tests errors

### DIFF
--- a/requirements_extras.txt
+++ b/requirements_extras.txt
@@ -1,1 +1,1 @@
-turbodbc>=0.4.1
+turbodbc>=1.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
-pytest<3.0.0
+pytest>=3.1.0
 pytest-cov>=2.4.0
 mock>=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,11 @@
 [egg_info]
 #tag_build = dev
 
-[pytest]
+[tool:pytest]
 addopts= --tb native -v -r fxX
 python_files=test/*test_*.py
+filterwarnings =
+    error::DeprecationWarning
 
 [sqla_testing]
 requirement_cls=sqlalchemy_exasol.requirements:Requirements

--- a/test/test_exadialect_turbodbc.py
+++ b/test/test_exadialect_turbodbc.py
@@ -3,7 +3,8 @@ from sqlalchemy.engine import url as sa_url
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import eq_
 
-from sqlalchemy_exasol.turbodbc import EXADialect_turbodbc, DEFAULT_CONNECTION_PARAMS
+from sqlalchemy_exasol.turbodbc import (EXADialect_turbodbc, DEFAULT_CONNECTION_PARAMS,
+                                        DEFAULT_TURBODBC_PARAMS)
 
 
 class EXADialectTurbodbcTest(fixtures.TestBase):
@@ -19,6 +20,16 @@ class EXADialectTurbodbcTest(fixtures.TestBase):
         'pwd': 'tiger',
     }
 
+    @staticmethod
+    def _assert_connect_args(result, expected, expected_turbodbc):
+        eq_({k: v for k,v in result.items() if k != 'turbodbc_options'}, expected)
+        assert (result['turbodbc_options'].read_buffer_size.megabytes
+                == expected_turbodbc.get('read_buffer_size', 50))
+        assert (result['turbodbc_options'].parameter_sets_to_buffer
+                == expected_turbodbc.get('parameter_sets_to_buffer', 1000))
+        assert (result['turbodbc_options'].use_async_io
+                == expected_turbodbc.get('use_async_io', False))
+
     def setup(self):
         self.dialect = EXADialect_turbodbc()
 
@@ -27,17 +38,19 @@ class EXADialectTurbodbcTest(fixtures.TestBase):
         _, args = self.dialect.create_connect_args(url)
         return args
 
-    def assert_parsed(self, dsn, expected_connector, expected_args):
+    def assert_parsed(self, dsn, expected_connector, expected_args, expected_turbodbc_args):
         url = sa_url.make_url(dsn)
         connector, args = self.dialect.create_connect_args(url)
         eq_(connector, expected_connector)
-        eq_(args, expected_args)
+        self._assert_connect_args(args, expected_args, expected_turbodbc_args)
+
 
     def test_create_connect_args(self):
         expected = self.default_host_args.copy()
         expected.update(self.default_user_args)
         expected.update(DEFAULT_CONNECTION_PARAMS)
-        self.assert_parsed("exa+turbodbc://scott:tiger@192.168.1.2..8:1234/my_schema", [None], expected)
+        self.assert_parsed("exa+turbodbc://scott:tiger@192.168.1.2..8:1234/my_schema", [None],
+                           expected, {})
 
     def test_create_connect_args_with_driver(self):
         expected = self.default_host_args.copy()
@@ -46,21 +59,31 @@ class EXADialectTurbodbcTest(fixtures.TestBase):
         expected['driver'] = 'EXASolo'
         self.assert_parsed(
             "exa+turbodbc://scott:tiger@192.168.1.2..8:1234/my_schema?driver=EXASolo",
-            [None], expected)
+            [None], expected, {})
+
+    def test_create_connect_args_dsn_without_user(self):
+        self.assert_parsed("exa+turbodbc://exa_test", ['exa_test'],
+                           DEFAULT_CONNECTION_PARAMS, {})
 
     def test_create_connect_args_dsn(self):
         expected = self.default_user_args.copy()
         expected.update(DEFAULT_CONNECTION_PARAMS)
-        self.assert_parsed("exa+pyodbc://scott:tiger@exa_test", ['exa_test'], expected)
+        self.assert_parsed("exa+pyodbc://scott:tiger@exa_test", ['exa_test'], expected, {})
 
-    def test_create_connect_args_dsn_without_user(self):
-        self.assert_parsed("exa+pyodbc://exa_test", ['exa_test'],
-                           DEFAULT_CONNECTION_PARAMS)
+    def test_create_connect_args_with_turbodbc_args(self):
+        expected = self.default_host_args.copy()
+        expected.update(self.default_user_args)
+        expected.update(DEFAULT_CONNECTION_PARAMS)
+        self.assert_parsed("exa+turbodbc://scott:tiger@192.168.1.2..8:1234/my_schema?"
+                           "read_buffer_size=4200&parameter_sets_to_buffer=111&use_async_io=True",
+                           [None], expected, {'read_buffer_size': 4200,
+                                              'parameter_sets_to_buffer': 111,
+                                              'use_async_io': True})
 
     def test_create_connect_args_trusted(self):
         expected = self.default_host_args.copy()
         expected.update(DEFAULT_CONNECTION_PARAMS)
-        self.assert_parsed("exa+pyodbc://192.168.1.2..8:1234/my_schema", [None], expected)
+        self.assert_parsed("exa+pyodbc://192.168.1.2..8:1234/my_schema", [None], expected, {})
 
     def test_create_connect_args_with_custom_parameter(self):
         base_url = "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema"


### PR DESCRIPTION
pytest>=3.0.0 catches and collects warnings like DeprectaionWarnings which leads to failing sqlalchemy tests of the test suit. This is fixed by disabling this behaviour and make warnings to errors in tests. 
For this turbodbc deprecation warnings had to be fixed as well.