### PR TITLE
Mark wheels as universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,7 @@ profile_file=.profiles.txt
 [db]
 #specify default db connection string to run test against
 #default=exa+pyodbc://USER:PWD@IP_RANGE:PORT/SCHEMA
+
+[bdist_wheel]
+# Use this option if your package is pure-python
+universal = 1


### PR DESCRIPTION
The wheels contents are the same for each Python version, thus we only
need to generate a single wheel.