### PR TITLE
Add support for fixed length char types.

### DIFF
--- a/sqlalchemy_exasol/base.py
+++ b/sqlalchemy_exasol/base.py
@@ -574,6 +574,8 @@ class EXADialect(default.DefaultDialect):
             try:
                 if coltype == 'VARCHAR':
                     coltype = sqltypes.VARCHAR(length)
+                elif coltype == 'CHAR':
+                    coltype = sqltypes.CHAR(length)
                 elif coltype == 'DECIMAL':
                     # this Dialect forces INTTYPESINRESULTSIFPOSSIBLE=y on ODBC level
                     # thus, we need to convert DECIMAL(<=18,0) back to INTEGER type


### PR DESCRIPTION
The current implementation loses information about the length of a Char field, which is problematic when trying to create tables using a `Table` defined in SQLAlchemy, 