### PR TITLE
GitHub Actions with Exasol Docker-DB for integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install via apt
+      run: sudo apt-get install unixodbc unixodbc-dev libboost-date-time-dev libboost-locale-dev libboost-system-dev
+    - name: Install pipenv
+      uses: dschep/install-pipenv-action@v1
+    - name: Pip Installer
+      uses: BSFishy/pip-action@v1
+      with:
+        requirements: 
+          - requirements.txt
+          - requirements_tests.txt
+    - name: Checkout test environment
+      run: git clone https://github.com/exasol/integration-test-docker-environment.git
+    - name: Spawn environemnt
+      run: push integration-test-docker-environment; ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666; popd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,13 +19,15 @@ jobs:
       run: sudo apt-get install unixodbc unixodbc-dev libboost-date-time-dev libboost-locale-dev libboost-system-dev
     - name: Install pipenv
       uses: dschep/install-pipenv-action@v1
-    - name: Pip Installer
+    - name: Pip install requirements
       uses: BSFishy/pip-action@v1
       with:
-        requirements: 
-          - requirements.txt
-          - requirements_tests.txt
+        requirements: requirements.txt
+    - name: Pip install requirements
+      uses: BSFishy/pip-action@v1
+      with:
+        requirements: requirements_test.txt
     - name: Checkout test environment
       run: git clone https://github.com/exasol/integration-test-docker-environment.git
     - name: Spawn environemnt
-      run: push integration-test-docker-environment; ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666; popd
+      run: pushd integration-test-docker-environment; ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666; popd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,28 +6,61 @@ on:
   pull_request:
     branches: [ "master" ]
 
+env:
+  ODBCSYSINI: $TRAVIS_BUILD_DIR/odbcconfig
+
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.6, 2.7]
+        connector:
+          - pyodbc          
+          - turbodbc
+    env:
+      TESTDB: "exa+${{ matrix.connector }}://sys:exasol@$localhost:8888/TEST?CONNECTIONLCALL=en_US.UTF-8&DRIVER=EXAODBC"
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Python
+
+    - name: Setup Python 3.6 for integration-test-docker-environment
       uses: actions/setup-python@v2
       with:
         python-version: 3.6
+      if: ${{ matrix.python != 3.6 }}
+
+    - name: Setup Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
     - name: Install via apt
       run: sudo apt-get install unixodbc unixodbc-dev libboost-date-time-dev libboost-locale-dev libboost-system-dev
+
     - name: Install pipenv
       uses: dschep/install-pipenv-action@v1
+
     - name: Pip install requirements
       uses: BSFishy/pip-action@v1
       with:
         requirements: requirements.txt
-    - name: Pip install requirements
+
+    - name: Pip install test requirements
       uses: BSFishy/pip-action@v1
       with:
         requirements: requirements_test.txt
+
+    - name: Pip install extra requirements
+      uses: BSFishy/pip-action@v1
+      with:
+        requirements: requirements_extras.txt
+      if: ${{ matrix.connector == 'turbodbc' }}
+
     - name: Checkout test environment
       run: git clone https://github.com/exasol/integration-test-docker-environment.git
+
     - name: Spawn environemnt
       run: pushd integration-test-docker-environment; ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666; popd
+
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches: [ "master" ]
 
-env:
-  ODBCSYSINI: $TRAVIS_BUILD_DIR/odbcconfig
 
 
 jobs:
@@ -19,8 +17,6 @@ jobs:
         connector:
           - pyodbc          
           - turbodbc
-    env:
-      TESTDB: "exa+${{ matrix.connector }}://sys:exasol@$localhost:8888/TEST?CONNECTIONLCALL=en_US.UTF-8&DRIVER=EXAODBC"
     steps:
     - uses: actions/checkout@v2
 
@@ -61,6 +57,16 @@ jobs:
       run: git clone https://github.com/exasol/integration-test-docker-environment.git
 
     - name: Spawn environemnt
-      run: pushd integration-test-docker-environment; ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666; popd
+      run: pushd integration-test-docker-environment; ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666; popd; rm -rf integration-test-docker-environment
 
+    - name: Prepare odbcinst.ini
+      run: echo DRIVER=$GITHUB_WORKSPACE/driver/libexaodbc-uo2214lv1.so >> odbcconfig/odbcinst.ini; cat odbcconfig/odbcinst.ini; ls -l $GITHUB_WORKSPACE
+
+    - name: Run tests
+      run: export ODBCSYSINI=$GITHUB_WORKSPACE/odbcconfig; py.test --dropfirst --cov-config=.coveragerc --cov=sqlalchemy_exasol --dburi "$TESTDB"
+      env:
+        TESTDB: "exa+${{ matrix.connector }}://sys:exasol@localhost:8888/TEST?CONNECTIONLCALL=en_US.UTF-8&DRIVER=EXAODBC"
+
+    - name: Coveralls GitHub Action
+      uses: coverallsapp/github-action@v1.1.1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,9 @@ jobs:
     - name: Checkout test environment
       run: git clone https://github.com/exasol/integration-test-docker-environment.git
 
+    - name: Add TEST_SCHEMA to test DDL
+      run: echo "CREATE SCHEMA TEST_SCHEMA;" >> integration-test-docker-environment/tests/test/enginedb_small/schema.sql
+
     - name: Spawn environemnt
       run: pushd integration-test-docker-environment; ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666; popd; rm -rf integration-test-docker-environment
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,9 @@ jobs:
     - name: Add TEST_SCHEMA to test DDL
       run: echo "CREATE SCHEMA TEST_SCHEMA;" >> integration-test-docker-environment/tests/test/enginedb_small/schema.sql
 
+    - name: Add TEST_SCHEMA_2 to test DDL
+      run: echo "CREATE SCHEMA_2 TEST_SCHEMA;" >> integration-test-docker-environment/tests/test/enginedb_small/schema.sql
+
     - name: Spawn environemnt
       run: pushd integration-test-docker-environment; ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666; popd; rm -rf integration-test-docker-environment
 


### PR DESCRIPTION
This is a first incomplete draft for moving the integration test for the Exasol SQLAlchemy Dialect to Github Actions and using Exasol Docker DB as target DB.
Currently, a lot test fail, probably because we need to add the necessary test schema. Further, it currently misses the upload to the pypi, but that should be not too difficult to add. The usage of coveralls needs probably also a check, if it works as intended. 