### PR TITLE
Performance improvement for single table reflection

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -74,7 +74,7 @@ jobs:
       working-directory: ../integration-test-docker-environment
 
     - name: Spawn EXASOL environemnt
-      run: ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666 --docker-db-image-version ${{ matrix.exasol_version }}
+      run: ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666 --docker-db-image-version ${{ matrix.exasol_version }} --db-mem-size 4GB
       working-directory: ../integration-test-docker-environment
 
     - name: Prepare odbcinst.ini

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
       working-directory: ../integration-test-docker-environment
 
     - name: Spawn EXASOL environemnt
-      run: ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666 --docker-db-image-version ${{ matrix.exasol_version }}
+      run: ./start-test-env spawn-test-environment --environment-name test --database-port-forward 8888 --bucketfs-port-forward 6666 --docker-db-image-version ${{ matrix.exasol_version }} --db-mem-size 4GB
       working-directory: ../integration-test-docker-environment
 
     - name: Prepare odbcinst.ini

--- a/test/test_deadlock.py
+++ b/test/test_deadlock.py
@@ -60,13 +60,12 @@ class MetadataTest(fixtures.TablesTest):
 
         self.run_deadlock_for_table(without_fallback)
 
-    def test_deadlock_for_get_pk_constraint_with_fallback(self):
+    def test_no_deadlock_for_get_pk_constraint_with_fallback(self):
         def with_fallback(session2, schema, table):
             dialect = EXADialect()
             dialect.get_pk_constraint(session2, table_name=table, schema=schema, use_sql_fallback=True)
 
-        with pytest.raises(Exception):
-            self.run_deadlock_for_table(with_fallback)
+        self.run_deadlock_for_table(with_fallback)
 
     def test_no_deadlock_for_get_foreign_keys_without_fallback(self):
         def without_fallback(session2, schema, table):
@@ -76,13 +75,12 @@ class MetadataTest(fixtures.TablesTest):
         self.run_deadlock_for_table(without_fallback)
 
 
-    def test_deadlock_for_get_foreign_keys_with_fallback(self):
+    def test_no_deadlock_for_get_foreign_keys_with_fallback(self):
         def with_fallback(session2, schema, table):
             dialect = EXADialect()
             dialect.get_foreign_keys(session2, table_name=table, schema=schema, use_sql_fallback=True)
 
-        with pytest.raises(Exception):
-            self.run_deadlock_for_table(with_fallback)
+        self.run_deadlock_for_table(with_fallback)
 
     def test_no_deadlock_for_get_view_names_without_fallback(self):
         # TODO: think of other scenarios where metadata deadlocks with view could happen

--- a/test/test_large_metadata.py
+++ b/test/test_large_metadata.py
@@ -1,0 +1,78 @@
+# -*- coding: UTF-8 -*-
+import time
+
+import pytest
+from sqlalchemy.testing import fixtures, config
+from sqlalchemy import MetaData, Table, Column, Integer
+
+
+table_counts = [1,50,100]
+column_counts = [3,30,300]
+
+class LargeMetadataTest(fixtures.TablesTest):
+    __backend__ = True
+
+
+    def create_table_ddl(self, schema, name, column_count):
+        table_template = "CREATE TABLE {schema}.{table} ({columns})"
+        columns = ["column_column_%s int" % i for i in range(column_count)]
+        columns_str = ",".join(columns)
+        table_str = table_template.format(schema=schema, table=name, columns=columns_str)
+        return table_str
+
+    @classmethod
+    def define_tables(cls, metadata):
+        cls.schema = "LargeMetadataTest".upper()
+
+    def get_table_name(self, table_count, column_count, i):
+        return "table_%s_%s_table_%s" % (table_count, column_count, i)
+
+    def test_reflect_table_object(self):
+        for table_count in table_counts:
+            for column_count in column_counts:
+                with config.db.begin() as c:
+                    try:
+                        c.execute("DROP SCHEMA %s CASCADE" % self.schema)
+                    except Exception as e:
+                        print(e)
+                        pass
+                    c.execute("CREATE SCHEMA %s" % self.schema)
+                    for i in range(table_count):
+                        table_name=self.get_table_name(table_count,column_count,i)
+                        table_ddl=self.create_table_ddl(self.schema,table_name,column_count)
+                        c.execute(table_ddl)
+
+                meta = MetaData(bind=config.db)
+                table_name = self.get_table_name(table_count, column_count, 0)
+                start = time.time()
+                users_table = Table(table_name,meta,autoload=True, schema=self.schema)
+                end = time.time()
+                print("table load timer: attempt: 1, table_count: %s, column_count: %s, time: %s"%(table_count,column_count,
+                      (end-start)))
+                start = time.time()
+                users_table = Table(table_name,meta,autoload=True, schema=self.schema)
+                end = time.time()
+                print("table load timer: attempt: 2, table_count: %s, column_count: %s, time: %s"%(table_count,column_count,
+                      (end-start)))
+                meta = None
+
+    def test_reflect_metadata_object(self):
+        for table_count in table_counts:
+            for column_count in column_counts:
+                with config.db.begin() as c:
+                    try:
+                        c.execute("DROP SCHEMA %s CASCADE" % self.schema)
+                    except Exception as e:
+                        print(e)
+                        pass
+                    c.execute("CREATE SCHEMA %s" % self.schema)
+                    for i in range(table_count):
+                        table_name=self.get_table_name(table_count,column_count,i)
+                        table_ddl=self.create_table_ddl(self.schema,table_name,column_count)
+                        c.execute(table_ddl)
+                meta = MetaData(bind=config.db)
+                start = time.time()
+                meta.reflect()
+                end = time.time()
+                print("all tables (MetaData.reflect) load timer: table_count: %s, column_count: %s, time: %s"%(table_count,column_count,
+                      (end-start)))


### PR DESCRIPTION
We observed that the Metadata reflection of the Exasol SQLAlchemy dialects gets really slow for databases with many tables and many columns per table. As specially, the first reflection operation on a table is costly, after that it gets compensated by the cache. Following a measurement of the runtime for metadata.reflect and Table(...,autload=True) with the latest commit of the dialect.

```
test/test_large_metadata.py::LargeMetadataTest_exasol+pyodbc_6_2_6::test_reflect_metadata_object 

all tables (MetaData.reflect) load timer: table_count: 1, column_count: 3, time: 8.062235593795776
all tables (MetaData.reflect) load timer: table_count: 1, column_count: 30, time: 8.75434160232544
all tables (MetaData.reflect) load timer: table_count: 1, column_count: 300, time: 9.442431449890137
all tables (MetaData.reflect) load timer: table_count: 50, column_count: 3, time: 10.306317567825317
all tables (MetaData.reflect) load timer: table_count: 50, column_count: 30, time: 11.116487979888916
all tables (MetaData.reflect) load timer: table_count: 50, column_count: 300, time: 12.039783477783203
all tables (MetaData.reflect) load timer: table_count: 100, column_count: 3, time: 13.176645278930664
all tables (MetaData.reflect) load timer: table_count: 100, column_count: 30, time: 13.981483936309814
all tables (MetaData.reflect) load timer: table_count: 100, column_count: 300, time: 15.208103656768799

test/test_large_metadata.py::LargeMetadataTest_exasol+pyodbc_6_2_6::test_reflect_table_object 

table load timer: attempt: 1, table_count: 1, column_count: 3, time: 0.09263920783996582
table load timer: attempt: 2, table_count: 1, column_count: 3, time: 3.24249267578125e-05
table load timer: attempt: 1, table_count: 1, column_count: 30, time: 0.09536314010620117
table load timer: attempt: 2, table_count: 1, column_count: 30, time: 2.5987625122070312e-05
table load timer: attempt: 1, table_count: 1, column_count: 300, time: 0.10527205467224121
table load timer: attempt: 2, table_count: 1, column_count: 300, time: 2.5987625122070312e-05
table load timer: attempt: 1, table_count: 50, column_count: 3, time: 0.13130879402160645
table load timer: attempt: 2, table_count: 50, column_count: 3, time: 3.0517578125e-05
table load timer: attempt: 1, table_count: 50, column_count: 30, time: 0.1890580654144287
table load timer: attempt: 2, table_count: 50, column_count: 30, time: 2.4080276489257812e-05
table load timer: attempt: 1, table_count: 50, column_count: 300, time: 0.6458144187927246
table load timer: attempt: 2, table_count: 50, column_count: 300, time: 2.8848648071289062e-05
table load timer: attempt: 1, table_count: 100, column_count: 3, time: 0.17120885848999023
table load timer: attempt: 2, table_count: 100, column_count: 3, time: 2.1457672119140625e-05
table load timer: attempt: 1, table_count: 100, column_count: 30, time: 0.2620224952697754
table load timer: attempt: 2, table_count: 100, column_count: 30, time: 2.4557113647460938e-05
table load timer: attempt: 1, table_count: 100, column_count: 300, time: 1.2848365306854248
table load timer: attempt: 2, table_count: 100, column_count: 300, time: 3.0279159545898438e-05
```
_The second attempt is there to show if the cache works. For the metadata.reflect we removed the second attempt, because for some reason it doesn't use the cache_

We improved the implementation by filtering the Exasol metadata tables with the respective table name instead of loading all the rows for the specified schema. Additionally, we checked that the cache is activated for all necessary methods. The following measurements show the runtime with the improvements. 

```
test/test_large_metadata.py::LargeMetadataTest_exasol+pyodbc_6_2_6::test_reflect_metadata_object 

all tables (MetaData.reflect) load timer: table_count: 1, column_count: 3, time: 5.613577842712402
all tables (MetaData.reflect) load timer: table_count: 1, column_count: 30, time: 5.710379362106323
all tables (MetaData.reflect) load timer: table_count: 1, column_count: 300, time: 5.8216822147369385
all tables (MetaData.reflect) load timer: table_count: 50, column_count: 3, time: 5.836512804031372
all tables (MetaData.reflect) load timer: table_count: 50, column_count: 30, time: 5.902085304260254
all tables (MetaData.reflect) load timer: table_count: 50, column_count: 300, time: 6.015064001083374
all tables (MetaData.reflect) load timer: table_count: 100, column_count: 3, time: 5.993046045303345
all tables (MetaData.reflect) load timer: table_count: 100, column_count: 30, time: 6.062432765960693
all tables (MetaData.reflect) load timer: table_count: 100, column_count: 300, time: 6.147905349731445

test/test_large_metadata.py::LargeMetadataTest_exasol+pyodbc_6_2_6::test_reflect_table_object table 

load timer: attempt: 1, table_count: 1, column_count: 3, time: 0.08960795402526855
table load timer: attempt: 2, table_count: 1, column_count: 3, time: 2.3126602172851562e-05
table load timer: attempt: 1, table_count: 1, column_count: 30, time: 0.09865927696228027
table load timer: attempt: 2, table_count: 1, column_count: 30, time: 2.4318695068359375e-05
table load timer: attempt: 1, table_count: 1, column_count: 300, time: 0.11870288848876953
table load timer: attempt: 2, table_count: 1, column_count: 300, time: 2.5510787963867188e-05
table load timer: attempt: 1, table_count: 50, column_count: 3, time: 0.11921977996826172
table load timer: attempt: 2, table_count: 50, column_count: 3, time: 2.47955322265625e-05
table load timer: attempt: 1, table_count: 50, column_count: 30, time: 0.11621880531311035
table load timer: attempt: 2, table_count: 50, column_count: 30, time: 2.8133392333984375e-05
table load timer: attempt: 1, table_count: 50, column_count: 300, time: 0.1204843521118164
table load timer: attempt: 2, table_count: 50, column_count: 300, time: 2.3126602172851562e-05
table load timer: attempt: 1, table_count: 100, column_count: 3, time: 0.08585453033447266
table load timer: attempt: 2, table_count: 100, column_count: 3, time: 2.6464462280273438e-05
table load timer: attempt: 1, table_count: 100, column_count: 30, time: 0.09429001808166504
table load timer: attempt: 2, table_count: 100, column_count: 30, time: 0.0001659393310546875
table load timer: attempt: 1, table_count: 100, column_count: 300, time: 0.11942219734191895
table load timer: attempt: 2, table_count: 100, column_count: 300, time: 2.4318695068359375e-05

```
For high table and column count, we are now not much slower than for low table and column count, in contrast to the old implementation. Furthermore, metadata.reflect got also faster and grows now much slower than with the old implementation.

An interesting site effect of this optimization was, that it also solved two deadlock scenarios from test_deadlock.py and it discovered a bug with the use_sql_fallback option (mainly used for testing purposes) in get_columns.