### PR TITLE
bug/#118 pyodbc based dialect exception/error mapping does not seemt to work properly

### DIFF
--- a/sqlalchemy_exasol/pyodbc.py
+++ b/sqlalchemy_exasol/pyodbc.py
@@ -88,6 +88,12 @@ class EXADialect_pyodbc(EXADialect, PyODBCConnector):
         opts.update(url.query)
         # always enable efficient conversion to Python types: see https://www.exasol.com/support/browse/EXASOL-898
         opts["INTTYPESINRESULTSIFPOSSIBLE"] = "y"
+        # Make sure the exasol odbc driver reports the expected error codes.
+        # see also:
+        #   * https://docs.exasol.com/db/latest/connect_exasol/drivers/odbc/using_odbc.htm
+        #   * https://github.com/exasol/sqlalchemy-exasol/issues/118
+        opts["SQLSTATEMAPPINGACTIVE"] = "y"
+        opts["SQLSTATEMAPPINGS"] = "42X91:23000,27002:23000"
 
         keys = opts
         query = url.query

--- a/sqlalchemy_exasol/pyodbc.py
+++ b/sqlalchemy_exasol/pyodbc.py
@@ -7,12 +7,14 @@ Connect string::
 """
 
 import re
-import six
 import sys
-from sqlalchemy_exasol.base import EXADialect, EXAExecutionContext
+from distutils.version import LooseVersion
+
+import six
 from sqlalchemy.connectors.pyodbc import PyODBCConnector
 from sqlalchemy.util.langhelpers import asbool
-from distutils.version import LooseVersion
+
+from sqlalchemy_exasol.base import EXADialect, EXAExecutionContext
 
 
 class EXADialect_pyodbc(EXADialect, PyODBCConnector):
@@ -28,83 +30,94 @@ class EXADialect_pyodbc(EXADialect, PyODBCConnector):
     def get_driver_version(self, connection):
         # LooseVersion will also work with interim versions like '4.2.7dev1' or '5.0.rc4'
         if self.driver_version is None:
-            self.driver_version = LooseVersion( connection.connection.getinfo( self.dbapi.SQL_DRIVER_VER ) or '2.0.0' )
+            self.driver_version = LooseVersion(
+                connection.connection.getinfo(self.dbapi.SQL_DRIVER_VER) or "2.0.0"
+            )
         return self.driver_version
 
     def _get_server_version_info(self, connection):
         if self.server_version_info is None:
             # need to check if current version of EXAODBC returns proper server version
-            if self.get_driver_version(connection) >= LooseVersion('4.2.1'):
+            if self.get_driver_version(connection) >= LooseVersion("4.2.1"):
                 # v4.2.1 and above should deliver usable SQL_DBMS_VER
-                result = connection.connection.getinfo( self.dbapi.SQL_DBMS_VER ).split('.')
+                result = connection.connection.getinfo(self.dbapi.SQL_DBMS_VER).split(
+                    "."
+                )
             else:
                 # Older versions do not include patchlevels, so we need to get info through SQL call
                 query = "select PARAM_VALUE from SYS.EXA_METADATA where PARAM_NAME = 'databaseProductVersion'"
-                result = connection.execute(query).fetchone()[0].split('.')
+                result = connection.execute(query).fetchone()[0].split(".")
 
             # last version position can something like: '12-S' for an EXASolo
-            self.server_version_info = (int(result[0]), int(result[1]), int(result[2].split('-')[0]))
+            self.server_version_info = (
+                int(result[0]),
+                int(result[1]),
+                int(result[2].split("-")[0]),
+            )
 
         # return cached info
         return self.server_version_info
 
-    if sys.platform == 'darwin':
+    if sys.platform == "darwin":
+
         def connect(self, *cargs, **cparams):
             # Get connection
             conn = super(EXADialect_pyodbc, self).connect(*cargs, **cparams)
 
             # Set up encodings
-            conn.setdecoding(self.dbapi.SQL_CHAR, encoding='utf-8')
-            conn.setdecoding(self.dbapi.SQL_WCHAR, encoding='utf-8')
-            conn.setdecoding(self.dbapi.SQL_WMETADATA, encoding='utf-8')
+            conn.setdecoding(self.dbapi.SQL_CHAR, encoding="utf-8")
+            conn.setdecoding(self.dbapi.SQL_WCHAR, encoding="utf-8")
+            conn.setdecoding(self.dbapi.SQL_WMETADATA, encoding="utf-8")
 
             if six.PY2:
-                conn.setencoding(str, encoding='utf-8')
-                conn.setencoding(unicode, encoding='utf-8')
+                conn.setencoding(str, encoding="utf-8")
+                conn.setencoding(unicode, encoding="utf-8")
             else:
-                conn.setencoding(encoding='utf-8')
+                conn.setencoding(encoding="utf-8")
 
             # Return connection
             return conn
 
     def create_connect_args(self, url):
         """
-        Connection strings are EXASolution specific. See EXASolution manual
-        on Connection-String-Parameters
+        Connection strings are EXASolution specific. See EXASolution manual on Connection-String-Parameters.
+
+        `ODBC Driver Settings <https://docs.exasol.com/db/latest/connect_exasol/drivers/odbc/using_odbc.htm>`_
         """
-        opts = url.translate_connect_args(username='user')
+        opts = url.translate_connect_args(username="user")
         opts.update(url.query)
         # always enable efficient conversion to Python types: see https://www.exasol.com/support/browse/EXASOL-898
-        opts['INTTYPESINRESULTSIFPOSSIBLE'] = 'y'
+        opts["INTTYPESINRESULTSIFPOSSIBLE"] = "y"
 
         keys = opts
         query = url.query
 
         connect_args = {}
-        for param in ('ansi', 'unicode_results', 'autocommit'):
+        for param in ("ansi", "unicode_results", "autocommit"):
             if param in keys:
                 connect_args[param.upper()] = asbool(keys.pop(param))
 
-        dsn_connection = 'dsn' in keys or \
-                        ('host' in keys and 'port' not in keys)
+        dsn_connection = "dsn" in keys or ("host" in keys and "port" not in keys)
         if dsn_connection:
-            connectors = ['DSN=%s' % (keys.pop('dsn', '') or \
-                        keys.pop('host', ''))]
+            connectors = ["DSN=%s" % (keys.pop("dsn", "") or keys.pop("host", ""))]
         else:
-            connectors = ["DRIVER={%s}" %
-                    keys.pop('driver', None)]
+            connectors = ["DRIVER={%s}" % keys.pop("driver", None)]
 
-        port = ''
-        if 'port' in keys and not 'port' in query:
-            port = ':%d' % int(keys.pop('port'))
+        port = ""
+        if "port" in keys and not "port" in query:
+            port = ":%d" % int(keys.pop("port"))
 
-        connectors.extend(['EXAHOST=%s%s' % (keys.pop('host', ''), port),
-                          'EXASCHEMA=%s' % keys.pop('database', '')])
+        connectors.extend(
+            [
+                "EXAHOST=%s%s" % (keys.pop("host", ""), port),
+                "EXASCHEMA=%s" % keys.pop("database", ""),
+            ]
+        )
 
         user = keys.pop("user", None)
         if user:
             connectors.append("UID=%s" % user)
-            connectors.append("PWD=%s" % keys.pop('password', ''))
+            connectors.append("PWD=%s" % keys.pop("password", ""))
         else:
             connectors.append("Trusted_Connection=Yes")
 
@@ -112,26 +125,25 @@ class EXADialect_pyodbc(EXADialect, PyODBCConnector):
         # convert textual data from your database encoding to your
         # client encoding.  This should obviously be set to 'No' if
         # you query a cp1253 encoded database from a latin1 client...
-        if 'odbc_autotranslate' in keys:
-            connectors.append("AutoTranslate=%s" %
-                                keys.pop("odbc_autotranslate"))
+        if "odbc_autotranslate" in keys:
+            connectors.append("AutoTranslate=%s" % keys.pop("odbc_autotranslate"))
 
-        connectors.extend(['%s=%s' % (k, v) for k, v in sorted(six.iteritems(keys))])
+        connectors.extend(["%s=%s" % (k, v) for k, v in sorted(six.iteritems(keys))])
         return [[";".join(connectors)], connect_args]
 
     def is_disconnect(self, e, connection, cursor):
         if isinstance(e, self.dbapi.Error):
             error_codes = {
-                '40004', # Connection lost.
-                '40009', # Connection lost after internal server error.
-                '40018', # Connection lost after system running out of memory.
-                '40020', # Connection lost after system running out of memory.
+                "40004",  # Connection lost.
+                "40009",  # Connection lost after internal server error.
+                "40018",  # Connection lost after system running out of memory.
+                "40020",  # Connection lost after system running out of memory.
             }
             exasol_error_codes = {
-                'HY000': (  # Generic Exasol error code
-                    re.compile(six.u(r'operation timed out'), re.IGNORECASE),
-                    re.compile(six.u(r'connection lost'), re.IGNORECASE),
-                    re.compile(six.u(r'Socket closed by peer'), re.IGNORECASE),
+                "HY000": (  # Generic Exasol error code
+                    re.compile(six.u(r"operation timed out"), re.IGNORECASE),
+                    re.compile(six.u(r"connection lost"), re.IGNORECASE),
+                    re.compile(six.u(r"Socket closed by peer"), re.IGNORECASE),
                 )
             }
 

--- a/sqlalchemy_exasol/requirements.py
+++ b/sqlalchemy_exasol/requirements.py
@@ -158,7 +158,7 @@ class Requirements(SuiteRequirements):
 
     @property
     def duplicate_key_raises_integrity_error(self):
-        return exclusions.closed()
+        return exclusions.open()
 
     @property
     def independent_connections(self):

--- a/sqlalchemy_exasol/requirements.py
+++ b/sqlalchemy_exasol/requirements.py
@@ -158,7 +158,9 @@ class Requirements(SuiteRequirements):
 
     @property
     def duplicate_key_raises_integrity_error(self):
-        return exclusions.open()
+        return exclusions.only_on(
+            [lambda config: config.db.dialect.driver == 'pyodbc']
+        )
 
     @property
     def independent_connections(self):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,10 @@
 from sqlalchemy.dialects import registry
+import pytest
 
 registry.register("exa.pyodbc", "sqlalchemy_exasol.pyodbc", "EXADialect_pyodbc")
 registry.register("exa.turbodbc", "sqlalchemy_exasol.turbodbc", "EXADialect_turbodbc")
+
+# Suppress spurious warning from pytest
+pytest.register_assert_rewrite("sqlalchemy.testing.assertions")
 
 from sqlalchemy.testing.plugin.pytestplugin import *

--- a/test/test_exadialect_pyodbc.py
+++ b/test/test_exadialect_pyodbc.py
@@ -26,6 +26,8 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
             "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?driver=EXAODBC",
             [
                 "DRIVER={EXAODBC};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y"
+                ";SQLSTATEMAPPINGACTIVE=y"
+                ";SQLSTATEMAPPINGS=42X91:23000,27002:23000"
             ],
             {},
         )
@@ -35,6 +37,8 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
             "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?driver=FOOBAR",
             [
                 "DRIVER={FOOBAR};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y"
+                ";SQLSTATEMAPPINGACTIVE=y"
+                ";SQLSTATEMAPPINGS=42X91:23000,27002:23000"
             ],
             {},
         )
@@ -44,6 +48,8 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
             "exa+pyodbc://scott:tiger@exa_test",
             [
                 "DSN=exa_test;EXAHOST=;EXASCHEMA=;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y"
+                ";SQLSTATEMAPPINGACTIVE=y"
+                ";SQLSTATEMAPPINGS=42X91:23000,27002:23000"
             ],
             {},
         )
@@ -53,6 +59,8 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
             "exa+pyodbc://192.168.1.2..8:1234/my_schema",
             [
                 "DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;Trusted_Connection=Yes;INTTYPESINRESULTSIFPOSSIBLE=y"
+                ";SQLSTATEMAPPINGACTIVE=y"
+                ";SQLSTATEMAPPINGS=42X91:23000,27002:23000"
             ],
             {},
         )
@@ -62,6 +70,8 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
             "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?odbc_autotranslate=Yes",
             [
                 "DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;AutoTranslate=Yes;INTTYPESINRESULTSIFPOSSIBLE=y"
+                ";SQLSTATEMAPPINGACTIVE=y"
+                ";SQLSTATEMAPPINGS=42X91:23000,27002:23000"
             ],
             {},
         )
@@ -71,6 +81,8 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
             "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?autocommit=true",
             [
                 "DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y"
+                ";SQLSTATEMAPPINGACTIVE=y"
+                ";SQLSTATEMAPPINGS=42X91:23000,27002:23000"
             ],
             {"AUTOCOMMIT": True},
         )
@@ -80,6 +92,8 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
             "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?autocommit=true&ansi=false&unicode_results=false",
             [
                 "DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y"
+                ";SQLSTATEMAPPINGACTIVE=y"
+                ";SQLSTATEMAPPINGS=42X91:23000,27002:23000"
             ],
             {"AUTOCOMMIT": True, "ANSI": False, "UNICODE_RESULTS": False},
         )
@@ -88,7 +102,10 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
         self.assert_parsed(
             "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?clientname=test&querytimeout=10",
             [
-                "DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y;clientname=test;querytimeout=10"
+                "DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y"
+                ";SQLSTATEMAPPINGACTIVE=y"
+                 ";SQLSTATEMAPPINGS=42X91:23000,27002:23000"
+                ";clientname=test;querytimeout=10"
             ],
             {},
         )

--- a/test/test_exadialect_pyodbc.py
+++ b/test/test_exadialect_pyodbc.py
@@ -1,20 +1,15 @@
 import pyodbc
-
 from mock import Mock
-
-from sqlalchemy.engine import url as sa_url
-
-from sqlalchemy.pool import _ConnectionFairy
-
 from sqlalchemy import testing
-from sqlalchemy.testing import fixtures
-from sqlalchemy.testing import eq_
+from sqlalchemy.engine import url as sa_url
+from sqlalchemy.pool import _ConnectionFairy
+from sqlalchemy.testing import eq_, fixtures
 
 from sqlalchemy_exasol.pyodbc import EXADialect_pyodbc
 
 
 class EXADialect_pyodbcTest(fixtures.TestBase):
-    __skip_if__ = (lambda: testing.db.dialect.driver != 'pyodbc',)
+    __skip_if__ = (lambda: testing.db.dialect.driver != "pyodbc",)
 
     def setup(self):
         self.dialect = EXADialect_pyodbc()
@@ -26,50 +21,77 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
         eq_(connector, expected_connector)
         eq_(args, expected_args)
 
-
     def test_create_connect_args(self):
-        self.assert_parsed("exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?driver=EXAODBC",
-                 ['DRIVER={EXAODBC};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y'],
-                 {})
+        self.assert_parsed(
+            "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?driver=EXAODBC",
+            [
+                "DRIVER={EXAODBC};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y"
+            ],
+            {},
+        )
 
     def test_create_connect_args_with_driver(self):
-        self.assert_parsed("exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?driver=FOOBAR",
-                 ['DRIVER={FOOBAR};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y'],
-                 {})
+        self.assert_parsed(
+            "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?driver=FOOBAR",
+            [
+                "DRIVER={FOOBAR};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y"
+            ],
+            {},
+        )
 
     def test_create_connect_args_dsn(self):
-        self.assert_parsed("exa+pyodbc://scott:tiger@exa_test",
-                 ['DSN=exa_test;EXAHOST=;EXASCHEMA=;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y'],
-                 {})
+        self.assert_parsed(
+            "exa+pyodbc://scott:tiger@exa_test",
+            [
+                "DSN=exa_test;EXAHOST=;EXASCHEMA=;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y"
+            ],
+            {},
+        )
 
     def test_create_connect_args_trusted(self):
-        self.assert_parsed("exa+pyodbc://192.168.1.2..8:1234/my_schema",
-                 ['DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;Trusted_Connection=Yes;INTTYPESINRESULTSIFPOSSIBLE=y'],
-                 {})
-
+        self.assert_parsed(
+            "exa+pyodbc://192.168.1.2..8:1234/my_schema",
+            [
+                "DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;Trusted_Connection=Yes;INTTYPESINRESULTSIFPOSSIBLE=y"
+            ],
+            {},
+        )
 
     def test_create_connect_args_autotranslate(self):
-        self.assert_parsed("exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?odbc_autotranslate=Yes",
-                 ['DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;AutoTranslate=Yes;INTTYPESINRESULTSIFPOSSIBLE=y'],
-                 {})
-
+        self.assert_parsed(
+            "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?odbc_autotranslate=Yes",
+            [
+                "DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;AutoTranslate=Yes;INTTYPESINRESULTSIFPOSSIBLE=y"
+            ],
+            {},
+        )
 
     def test_create_connect_args_with_param(self):
-        self.assert_parsed("exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?autocommit=true",
-                 ['DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y'],
-                 {'AUTOCOMMIT': True})
-
+        self.assert_parsed(
+            "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?autocommit=true",
+            [
+                "DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y"
+            ],
+            {"AUTOCOMMIT": True},
+        )
 
     def test_create_connect_args_with_param_multiple(self):
-        self.assert_parsed("exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?autocommit=true&ansi=false&unicode_results=false",
-                 ['DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y'],
-                 {'AUTOCOMMIT': True, 'ANSI': False, 'UNICODE_RESULTS': False})
-
+        self.assert_parsed(
+            "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?autocommit=true&ansi=false&unicode_results=false",
+            [
+                "DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y"
+            ],
+            {"AUTOCOMMIT": True, "ANSI": False, "UNICODE_RESULTS": False},
+        )
 
     def test_create_connect_args_with_unknown_params(self):
-        self.assert_parsed("exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?clientname=test&querytimeout=10",
-                 ['DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y;clientname=test;querytimeout=10'],
-                 {})
+        self.assert_parsed(
+            "exa+pyodbc://scott:tiger@192.168.1.2..8:1234/my_schema?clientname=test&querytimeout=10",
+            [
+                "DRIVER={None};EXAHOST=192.168.1.2..8:1234;EXASCHEMA=my_schema;UID=scott;PWD=tiger;INTTYPESINRESULTSIFPOSSIBLE=y;clientname=test;querytimeout=10"
+            ],
+            {},
+        )
 
     def test_is_disconnect(self):
         connection = Mock(spec=_ConnectionFairy)
@@ -77,12 +99,11 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
 
         errors = [
             pyodbc.Error(
-                'HY000',
-                '[HY000] [EXASOL][EXASolution driver]Connection lost in socket read attempt. Operation timed out (-1) (SQLExecDirectW)'
+                "HY000",
+                "[HY000] [EXASOL][EXASolution driver]Connection lost in socket read attempt. Operation timed out (-1) (SQLExecDirectW)",
             ),
             pyodbc.Error(
-                'HY000',
-                '[HY000] [EXASOL][EXASolution driver]Socket closed by peer.'
+                "HY000", "[HY000] [EXASOL][EXASolution driver]Socket closed by peer."
             ),
         ]
 

--- a/test/test_exadialect_pyodbc.py
+++ b/test/test_exadialect_pyodbc.py
@@ -3,7 +3,7 @@ from mock import Mock
 from sqlalchemy import testing
 from sqlalchemy.engine import url as sa_url
 from sqlalchemy.pool import _ConnectionFairy
-from sqlalchemy.testing import eq_, fixtures
+from sqlalchemy.testing import fixtures
 
 from sqlalchemy_exasol.pyodbc import EXADialect_pyodbc
 
@@ -18,8 +18,8 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
     def assert_parsed(self, dsn, expected_connector, expected_args):
         url = sa_url.make_url(dsn)
         connector, args = self.dialect.create_connect_args(url)
-        eq_(connector, expected_connector)
-        eq_(args, expected_args)
+        assert connector == expected_connector
+        assert args == expected_args
 
     def test_create_connect_args(self):
         self.assert_parsed(
@@ -109,5 +109,4 @@ class EXADialect_pyodbcTest(fixtures.TestBase):
 
         for error in errors:
             status = self.dialect.is_disconnect(error, connection, cursor)
-
-            eq_(status, True)
+            assert status


### PR DESCRIPTION
- Enable duplicate_key_raises_integrity_error test
- Supress spurious warning from pytest
- Add PK integrity tests to sqlalchemy-exasol test suite
- Reformat pyodbc.py and test_exadialect_pyodbc.py with black
