### PR TITLE
Adjust sha1 for commit containing reformatting the source code with black

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
-# Migrate code style to black
-8ac2a86f365fd841e54f26ff896041828494ea6e
+# Add support for automated code formatting (Migrate code style to black)
+d6c50bf103e78af237617f2ef216dfce875cf00f


### PR DESCRIPTION
Due to the fact that we @exasol use the sqash merge as default for all projects, the original commit (sha1) of the code reformat got lost and replaced/succeeded by the one of the squash merge commit.

[Context](https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html)