### PR TITLE
Add support for automatically organizing imports

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Add support for automated code formatting (Migrate code style to black)
 d6c50bf103e78af237617f2ef216dfce875cf00f
+# Add support for import sorting using isort
+d8bf67d942e4957a8801347e5c812161a5611f65

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,10 @@ SQLAlchemy Dialect for EXASOL DB
    :target: https://github.com/psf/black
    :alt: Formatter - Black
 
+.. image:: https://img.shields.io/badge/imports-isort-ef8336.svg
+   :target: https://pycqa.github.io/isort/
+   :alt: Formatter - Isort
+
 .. image:: https://img.shields.io/pypi/l/sqlalchemy-exasol
      :target: https://opensource.org/licenses/BSD-2-Clause
      :alt: License

--- a/noxfile.py
+++ b/noxfile.py
@@ -111,6 +111,7 @@ def fix(session):
         "--fix",
         f"{Settings.VERSION_FILE}",
     )
+    session.run("poetry", "run", "python", "-m", "isort", "-v", f"{PROJECT_ROOT}")
     session.run("poetry", "run", "python", "-m", "black", f"{PROJECT_ROOT}")
 
 
@@ -126,6 +127,13 @@ def code_format(session):
         "--diff",
         "--color",
         f"{PROJECT_ROOT}",
+    )
+
+
+@nox.session(python=False)
+def isort(session):
+    session.run(
+        "poetry", "run", "python", "-m", "isort", "-v", "--check", f"{PROJECT_ROOT}"
     )
 
 
@@ -146,6 +154,7 @@ def verify(session, connector, db_version):
             f"{version_from_python_module(Settings.VERSION_FILE)},"
             f"poetry: {version_from_poetry()}."
         )
+    session.notify("isort")
     session.notify("code-format")
     session.notify(find_session_runner(session, f"db-start(db_version='{db_version}')"))
     session.notify(

--- a/poetry.lock
+++ b/poetry.lock
@@ -148,6 +148,20 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "isort"
+version = "5.10.1"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -301,7 +315,7 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+testing = ["virtualenv", "pytest-xdist", "six", "process-tests", "hunter", "fields"]
 
 [[package]]
 name = "pytest-json-report"
@@ -429,7 +443,7 @@ turbodbc = []
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<4.0"
-content-hash = "294b4e8ece59cba0b496e1dbb2948614976ae173d87509378752f9e40ce9d22f"
+content-hash = "416ab025ef2e78206bf043f99a048fc20db99ea3753cf765085f225d48dcbd33"
 
 [metadata.files]
 argcomplete = [
@@ -443,7 +457,10 @@ attrs = [
 ]
 black = []
 cfgv = []
-click = []
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
@@ -462,6 +479,10 @@ identify = []
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -502,41 +523,7 @@ pytest = []
 pytest-cov = []
 pytest-json-report = []
 pytest-metadata = []
-pyyaml = [
-    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
-    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
-    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
-    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
-    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
-    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
-    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
-    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
-    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
-    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
-    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
-    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
-    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
-    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
-    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
-    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
-    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
-    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
-    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
-    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
-    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
-    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
-    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
-    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
-    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
-    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
-    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
-    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
-    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
-    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
-    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
-    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
-    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
-]
+pyyaml = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "sqlalchemy_exasol"
-version = "3.1.3"
+version = "3.1.4"
 description = "EXASOL dialect for SQLAlchemy"
 readme = "README.rst"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,7 @@ filterwarnings = [
 line-length = 88
 verbose = false
 include = "\\.pyi?$"
+
+[tool.isort]
+profile = "black"
+force_grid_wrap = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ pytest-cov = ">=2.7.0"
 pre-commit = "^2.19.0"
 wheel = "^0.37.1"
 black = "^22.6.0"
+isort = "^5.10.1"
 
 [tool.poetry.extras]
 turbodbc = ["turbodbc"]

--- a/scripts/git.py
+++ b/scripts/git.py
@@ -1,4 +1,7 @@
-from subprocess import PIPE, run
+from subprocess import (
+    PIPE,
+    run,
+)
 
 
 def tags():

--- a/scripts/links.py
+++ b/scripts/links.py
@@ -1,8 +1,11 @@
-import urllib.error
 import subprocess
+import urllib.error
 from itertools import repeat
 from pathlib import Path
-from typing import Iterable, Tuple
+from typing import (
+    Iterable,
+    Tuple,
+)
 from urllib import request
 
 

--- a/sqlalchemy_exasol/__init__.py
+++ b/sqlalchemy_exasol/__init__.py
@@ -1,5 +1,8 @@
+from sqlalchemy_exasol import (
+    base,
+    pyodbc,
+)
 from sqlalchemy_exasol.version import VERSION
-from sqlalchemy_exasol import base, pyodbc
 
 __version__ = VERSION
 

--- a/sqlalchemy_exasol/base.py
+++ b/sqlalchemy_exasol/base.py
@@ -45,18 +45,34 @@ representation (all uppercase).
 
 """
 
-import sqlalchemy.exc
-
+import logging
+import re
+from datetime import (
+    date,
+    datetime,
+)
 from decimal import Decimal
-from sqlalchemy import sql, schema, types as sqltypes, util, event
-from sqlalchemy.schema import AddConstraint, ForeignKeyConstraint
-from sqlalchemy.engine import default, reflection
+
+import sqlalchemy.exc
+from sqlalchemy import (
+    event,
+    schema,
+    sql,
+)
+from sqlalchemy import types as sqltypes
+from sqlalchemy import util
+from sqlalchemy.engine import (
+    default,
+    reflection,
+)
+from sqlalchemy.schema import (
+    AddConstraint,
+    ForeignKeyConstraint,
+)
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.elements import quoted_name
-from datetime import date, datetime
+
 from .constraints import DistributeByConstraint
-import re
-import logging
 
 logger = logging.getLogger("sqlalchemy_exasol")
 

--- a/sqlalchemy_exasol/merge.py
+++ b/sqlalchemy_exasol/merge.py
@@ -2,7 +2,12 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import Column
 from sqlalchemy.sql import crud
 from sqlalchemy.sql.base import _generative
-from sqlalchemy.sql.expression import ValuesBase, and_, UpdateBase, ColumnClause
+from sqlalchemy.sql.expression import (
+    ColumnClause,
+    UpdateBase,
+    ValuesBase,
+    and_,
+)
 
 
 class Merge(UpdateBase):

--- a/sqlalchemy_exasol/pyodbc.py
+++ b/sqlalchemy_exasol/pyodbc.py
@@ -6,17 +6,20 @@ Connect string::
 
 """
 
+import logging
 import re
 import sys
-import logging
-from packaging import version
 
+from packaging import version
 from sqlalchemy import sql
-from sqlalchemy.engine import reflection
 from sqlalchemy.connectors.pyodbc import PyODBCConnector
+from sqlalchemy.engine import reflection
 from sqlalchemy.util.langhelpers import asbool
 
-from sqlalchemy_exasol.base import EXADialect, EXAExecutionContext
+from sqlalchemy_exasol.base import (
+    EXADialect,
+    EXAExecutionContext,
+)
 
 logger = logging.getLogger("sqlalchemy_exasol")
 

--- a/sqlalchemy_exasol/requirements.py
+++ b/sqlalchemy_exasol/requirements.py
@@ -1,7 +1,9 @@
-from sqlalchemy.testing.requirements import SuiteRequirements
-from sqlalchemy.testing.exclusions import BooleanPredicate, skip_if
-
 from sqlalchemy.testing import exclusions
+from sqlalchemy.testing.exclusions import (
+    BooleanPredicate,
+    skip_if,
+)
+from sqlalchemy.testing.requirements import SuiteRequirements
 
 
 class Requirements(SuiteRequirements):

--- a/sqlalchemy_exasol/turbodbc.py
+++ b/sqlalchemy_exasol/turbodbc.py
@@ -1,9 +1,9 @@
 import decimal
 
-from sqlalchemy import types as sqltypes, util
+from sqlalchemy import types as sqltypes
+from sqlalchemy import util
 
 from sqlalchemy_exasol.base import EXADialect
-
 
 DEFAULT_CONNECTION_PARAMS = {
     # always enable efficient conversion to Python types:

--- a/sqlalchemy_exasol/util.py
+++ b/sqlalchemy_exasol/util.py
@@ -1,7 +1,7 @@
 import datetime
 
-from sqlalchemy_exasol.pyodbc import EXADialect_pyodbc
 from sqlalchemy_exasol import base
+from sqlalchemy_exasol.pyodbc import EXADialect_pyodbc
 
 
 def raw_sql(query):

--- a/sqlalchemy_exasol/version.py
+++ b/sqlalchemy_exasol/version.py
@@ -4,6 +4,6 @@
 
 MAJOR = 3
 MINOR = 1
-PATCH = 3
+PATCH = 4
 
 VERSION = f"{MAJOR}.{MINOR}.{PATCH}"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,5 @@
-from sqlalchemy.dialects import registry
 import pytest
+from sqlalchemy.dialects import registry
 
 registry.register("exa.pyodbc", "sqlalchemy_exasol.pyodbc", "EXADialect_pyodbc")
 registry.register("exa.turbodbc", "sqlalchemy_exasol.turbodbc", "EXADialect_turbodbc")

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -1,8 +1,12 @@
 import copy
+
 import pytest
 import sqlalchemy.exc
 from sqlalchemy import create_engine
-from sqlalchemy.testing.fixtures import config, TestBase
+from sqlalchemy.testing.fixtures import (
+    TestBase,
+    config,
+)
 
 
 class CertificateTest(TestBase):

--- a/test/test_deadlock.py
+++ b/test/test_deadlock.py
@@ -2,10 +2,13 @@ import time
 from threading import Thread
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.testing import fixtures, config
-from sqlalchemy.engine.reflection import Inspector
 import sqlalchemy.testing as testing
+from sqlalchemy import create_engine
+from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.testing import (
+    config,
+    fixtures,
+)
 
 
 # TODO: get_schema_names, get_view_names and get_view_definition didn't cause deadlocks in this scenario

--- a/test/test_exadialect_pyodbc.py
+++ b/test/test_exadialect_pyodbc.py
@@ -1,6 +1,7 @@
+from unittest.mock import Mock
+
 import pyodbc
 import pytest
-from unittest.mock import Mock
 from sqlalchemy import testing
 from sqlalchemy.engine import url as sa_url
 from sqlalchemy.pool import _ConnectionFairy

--- a/test/test_exadialect_turbodbc.py
+++ b/test/test_exadialect_turbodbc.py
@@ -1,10 +1,15 @@
 import pytest
 from sqlalchemy import testing
 from sqlalchemy.engine import url as sa_url
-from sqlalchemy.testing import fixtures
-from sqlalchemy.testing import eq_
+from sqlalchemy.testing import (
+    eq_,
+    fixtures,
+)
 
-from sqlalchemy_exasol.turbodbc import EXADialect_turbodbc, DEFAULT_CONNECTION_PARAMS
+from sqlalchemy_exasol.turbodbc import (
+    DEFAULT_CONNECTION_PARAMS,
+    EXADialect_turbodbc,
+)
 
 
 @pytest.mark.skipif(

--- a/test/test_exasol.py
+++ b/test/test_exasol.py
@@ -1,10 +1,27 @@
 import datetime
 
-from sqlalchemy import MetaData, Table, Column, Integer, String, Date, DateTime
-from sqlalchemy import or_, select, literal_column
-from sqlalchemy import testing, inspect
-from sqlalchemy.schema import DropConstraint, AddConstraint
-from sqlalchemy.testing import fixtures, config
+from sqlalchemy import (
+    Column,
+    Date,
+    DateTime,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    inspect,
+    literal_column,
+    or_,
+    select,
+    testing,
+)
+from sqlalchemy.schema import (
+    AddConstraint,
+    DropConstraint,
+)
+from sqlalchemy.testing import (
+    config,
+    fixtures,
+)
 
 from sqlalchemy_exasol.base import EXAExecutionContext
 from sqlalchemy_exasol.constraints import DistributeByConstraint

--- a/test/test_get_metadata_functions.py
+++ b/test/test_get_metadata_functions.py
@@ -1,9 +1,15 @@
 import pytest
 from sqlalchemy import create_engine
-from sqlalchemy.engine.url import URL
-from sqlalchemy.sql.sqltypes import INTEGER, VARCHAR
-from sqlalchemy.testing import fixtures, config
 from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.engine.url import URL
+from sqlalchemy.sql.sqltypes import (
+    INTEGER,
+    VARCHAR,
+)
+from sqlalchemy.testing import (
+    config,
+    fixtures,
+)
 
 TEST_GET_METADATA_FUNCTIONS_SCHEMA = "test_get_metadata_functions_schema"
 ENGINE_NONE_DATABASE = "ENGINE_NONE_DATABASE"

--- a/test/test_large_metadata.py
+++ b/test/test_large_metadata.py
@@ -1,8 +1,13 @@
 import time
 
-from sqlalchemy.testing import fixtures, config
-from sqlalchemy import MetaData, Table
-
+from sqlalchemy import (
+    MetaData,
+    Table,
+)
+from sqlalchemy.testing import (
+    config,
+    fixtures,
+)
 
 table_counts = [1, 50, 100]
 column_counts = [3, 30, 300]

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1,6 +1,14 @@
 """This module contains various regression test for issues which have been fixed in the past"""
 import pytest
-from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, inspect
+from sqlalchemy import (
+    Column,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    inspect,
+)
 from sqlalchemy.pool import (
     AssertionPool,
     NullPool,
@@ -8,7 +16,10 @@ from sqlalchemy.pool import (
     SingletonThreadPool,
     StaticPool,
 )
-from sqlalchemy.schema import CreateSchema, DropSchema
+from sqlalchemy.schema import (
+    CreateSchema,
+    DropSchema,
+)
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing.fixtures import config
 

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1,6 +1,7 @@
 # import all SQLAlchemy tests for this dialect
-import pytest
 from inspect import cleandoc
+
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.testing.suite import CompoundSelectTest as _CompoundSelectTest
 from sqlalchemy.testing.suite import ExceptionTest as _ExceptionTest

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -1,8 +1,15 @@
 import unittest
+
 from sqlalchemy import *
 from sqlalchemy import testing
-from sqlalchemy.testing import eq_, fixtures
-from sqlalchemy.testing.schema import Table, Column
+from sqlalchemy.testing import (
+    eq_,
+    fixtures,
+)
+from sqlalchemy.testing.schema import (
+    Column,
+    Table,
+)
 
 
 class _UpdateTestBase:


### PR DESCRIPTION
fixes #163 

- Add isort as dev dependency
- Add isort configuration to pyproject.toml
- Add targets for import sorting to noxfile
- Reformat the source code using isort import sorter
- Add sha1 of reformatting commit to ignore list
- Add isort badge to README
