### PR TITLE
Adjust sha1 for commit containing reformatting the source code with isort

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
 # Add support for automated code formatting (Migrate code style to black)
 d6c50bf103e78af237617f2ef216dfce875cf00f
 # Add support for import sorting using isort
-d8bf67d942e4957a8801347e5c812161a5611f65
+365fe6f53a47cdfc7e243119fcf7e02fc3daad2f


### PR DESCRIPTION
Due to the fact that we @exasol use the sqash merge as default for all projects, the original commit (sha1) of the code reformat got lost and replaced/succeeded by the one of the squash merge commit.

[Context](https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html)
