### PR TITLE
bug/#342 failing sqla compliance tests for ws dialect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Unreleased
 ---------
 
 - Fixed `prepared statements send the wrong types as parameters to the server <https://github.com/exasol/sqlalchemy-exasol/issues/341>`_
+- Fixed `Various SQLA compliance tests are failing for the websocket based dialect <https://github.com/exasol/sqlalchemy-exasol/issues/342>`_
 
 .. _changelog-4.5.1:
 

--- a/sqlalchemy_exasol/websocket.py
+++ b/sqlalchemy_exasol/websocket.py
@@ -30,7 +30,7 @@ class Decimal(sqltypes.DECIMAL):
 
     def result_processor(self, dialect, coltype):
         if not self.asdecimal:
-            return None
+            return lambda value: None if value is None else float(value)
 
         fstring = "%%.%df" % self._effective_decimal_return_scale
 

--- a/test/integration/sqlalchemy/test_suite.py
+++ b/test/integration/sqlalchemy/test_suite.py
@@ -23,11 +23,6 @@ from sqlalchemy.testing.suite.test_ddl import (
     LongNameBlowoutTest as _LongNameBlowoutTest,
 )
 
-ISSUE_342 = pytest.mark.xfail(
-    "websocket" in testing.db.dialect.driver,
-    reason="Not implemented yet see also https://github.com/exasol/sqlalchemy-exasol/issues/342",
-)
-
 
 class RowFetchTest(_RowFetchTest):
     RATIONAL = cleandoc(
@@ -71,7 +66,6 @@ class HasTableTest(_HasTableTest):
 
 
 class InsertBehaviorTest(_InsertBehaviorTest):
-    @ISSUE_342
     @pytest.mark.xfail(
         "turbodbc" in testing.db.dialect.driver,
         reason=cleandoc(
@@ -285,24 +279,10 @@ class NumericTest(_NumericTest):
         EXASOL and pyodbc."""
         ),
     )
-    @ISSUE_342
     @testing.requires.implicit_decimal_binds
     @testing.emits_warning(r".*does \*not\* support Decimal objects natively")
     def test_decimal_coerce_round_trip(self, connection):
         super().test_decimal_coerce_round_trip(connection)
-
-    @ISSUE_342
-    @testing.emits_warning(r".*does \*not\* support Decimal objects natively")
-    def test_render_literal_numeric_asfloat(self, literal_round_trip):
-        super().test_render_literal_numeric_asfloat(literal_round_trip)
-
-    @ISSUE_342
-    def test_numeric_as_float(self, do_numeric_test):
-        super().test_numeric_as_float(do_numeric_test)
-
-    @ISSUE_342
-    def test_float_coerce_round_trip(self, connection):
-        super().test_float_coerce_round_trip(connection)
 
 
 class QuotedNameArgumentTest(_QuotedNameArgumentTest):

--- a/test/integration/sqlalchemy/test_suite.py
+++ b/test/integration/sqlalchemy/test_suite.py
@@ -77,6 +77,11 @@ class InsertBehaviorTest(_InsertBehaviorTest):
         ),
         strict=True,
     )
+    @pytest.mark.xfail(
+        "websocket" in testing.db.dialect.driver,
+        reason="This currently isn't supported by the websocket protocol L3-1064.",
+        strict=True,
+    )
     @testing.requires.empty_inserts_executemany
     def test_empty_insert_multiple(self, connection):
         super().test_empty_insert_multiple(connection)


### PR DESCRIPTION
Fixes #342

- Reenable test for issue #342
- Convert Decimal type to float if decimal isn't enforced
- Mark unsupported feature as xfail
- Update changelog
