### PR TITLE
#801: Fix bare Exa dialect entry point

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -4,7 +4,7 @@
 
 ## Bugfixes
 
-* <!-- Issue reference pending explicit approval. --> Corrected the bare `exa`
+* #801: Corrected the bare `exa`
   SQLAlchemy entry point to load the default websocket dialect class directly. This
   keeps entry-point consumers such as Apache Superset working while preserving both
   `exa://` and `exa+websocket://` engine URLs.

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -2,11 +2,12 @@
 
 ## Summary
 
-## Bugfix
+## Bugfixes
 
-* Corrected the bare `exa` SQLAlchemy entry point to load the default websocket
-  dialect class directly. This keeps entry-point consumers such as Apache Superset
-  working while preserving both `exa://` and `exa+websocket://` engine URLs.
+* <!-- Issue reference pending explicit approval. --> Corrected the bare `exa`
+  SQLAlchemy entry point to load the default websocket dialect class directly. This
+  keeps entry-point consumers such as Apache Superset working while preserving both
+  `exa://` and `exa+websocket://` engine URLs.
 
 ## Documentation
 

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -2,6 +2,12 @@
 
 ## Summary
 
+## Bugfix
+
+* Corrected the bare `exa` SQLAlchemy entry point to load the default websocket
+  dialect class directly. This keeps entry-point consumers such as Apache Superset
+  working while preserving both `exa://` and `exa+websocket://` engine URLs.
+
 ## Documentation
 
 * #781: Added Connection Pooling to the User Guide

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ Issues = "https://github.com/exasol/sqlalchemy-exasol/issues"
 Changelog = "https://exasol.github.io/sqlalchemy-exasol/changelog.html"
 
 [project.entry-points."sqlalchemy.dialects"]
-"exa" = "sqlalchemy_exasol:base"
+"exa" = "sqlalchemy_exasol.websocket:EXADialect_websocket"
 "exa.websocket" = "sqlalchemy_exasol.websocket:EXADialect_websocket"
 
 [build-system]

--- a/test/unit/exasol/test_entry_points.py
+++ b/test/unit/exasol/test_entry_points.py
@@ -1,0 +1,57 @@
+from importlib.metadata import (
+    EntryPoint,
+    entry_points,
+)
+
+import pytest
+from packaging.utils import canonicalize_name
+from sqlalchemy import create_engine
+from sqlalchemy.engine.default import DefaultDialect
+
+from sqlalchemy_exasol.websocket import EXADialect_websocket
+
+ENTRY_POINT_NAMES = ("exa", "exa.websocket")
+
+
+def exasol_entry_points() -> dict[str, EntryPoint]:
+    """Return this distribution's installed SQLAlchemy dialect entry points."""
+    distribution_name = canonicalize_name("sqlalchemy-exasol")
+    return {
+        entry_point.name: entry_point
+        for entry_point in entry_points(group="sqlalchemy.dialects")
+        if entry_point.dist is not None
+        and canonicalize_name(entry_point.dist.name) == distribution_name
+    }
+
+
+def test_dialect_entry_points_are_discoverable():
+    discovered = exasol_entry_points()
+
+    assert set(discovered) == set(ENTRY_POINT_NAMES)
+
+
+@pytest.mark.parametrize("entry_point_name", ENTRY_POINT_NAMES)
+def test_dialect_entry_points_have_superset_shape(entry_point_name):
+    """Superset consumes the class returned directly by EntryPoint.load()."""
+    dialect = exasol_entry_points()[entry_point_name].load()
+
+    assert isinstance(dialect, type)
+    assert issubclass(dialect, DefaultDialect)
+    assert dialect.name == "exasol"
+    assert dialect.driver == "exasol.driver.websocket.dbapi2"
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "exa://user:password@localhost:8563/schema",
+        "exa+websocket://user:password@localhost:8563/schema",
+    ),
+)
+def test_create_engine_uses_websocket_dialect_without_connecting(url):
+    engine = create_engine(url)
+
+    try:
+        assert isinstance(engine.dialect, EXADialect_websocket)
+    finally:
+        engine.dispose()

--- a/test/unit/exasol/test_entry_points.py
+++ b/test/unit/exasol/test_entry_points.py
@@ -1,3 +1,13 @@
+"""Tests for the dialect entry points in the installed distribution metadata.
+
+These tests intentionally inspect installed metadata rather than ``pyproject.toml``.
+An editable install can retain stale entry-point metadata after ``pyproject.toml`` is
+edited, so developers must reinstall the project before running this module.  That
+tradeoff ensures the tests exercise the same metadata used by entry-point consumers.
+"""
+
+import subprocess
+import sys
 from importlib.metadata import (
     EntryPoint,
     entry_points,
@@ -5,9 +15,9 @@ from importlib.metadata import (
 
 import pytest
 from packaging.utils import canonicalize_name
-from sqlalchemy import create_engine
 from sqlalchemy.engine.default import DefaultDialect
 
+from sqlalchemy_exasol import base
 from sqlalchemy_exasol.websocket import EXADialect_websocket
 
 ENTRY_POINT_NAMES = ("exa", "exa.websocket")
@@ -35,23 +45,51 @@ def test_dialect_entry_points_have_superset_shape(entry_point_name):
     """Superset consumes the class returned directly by EntryPoint.load()."""
     dialect = exasol_entry_points()[entry_point_name].load()
 
+    assert dialect is EXADialect_websocket
     assert isinstance(dialect, type)
     assert issubclass(dialect, DefaultDialect)
     assert dialect.name == "exasol"
     assert dialect.driver == "exasol.driver.websocket.dbapi2"
 
 
+def test_bare_entry_point_matches_runtime_default():
+    dialect = exasol_entry_points()["exa"].load()
+
+    assert dialect is base.dialect
+
+
 @pytest.mark.parametrize(
-    "url",
+    ("entry_point_name", "url"),
     (
-        "exa://user:password@localhost:8563/schema",
-        "exa+websocket://user:password@localhost:8563/schema",
+        ("exa", "exa://user:password@localhost:8563/schema"),
+        (
+            "exa.websocket",
+            "exa+websocket://user:password@localhost:8563/schema",
+        ),
     ),
 )
-def test_create_engine_uses_websocket_dialect_without_connecting(url):
-    engine = create_engine(url)
+def test_create_engine_uses_installed_websocket_dialect_without_connecting(
+    entry_point_name, url
+):
+    """Use a clean interpreter so SQLAlchemy's registry cannot mask bad metadata."""
+    code = f"""
+from sqlalchemy import create_engine
+from sqlalchemy.dialects import registry
+from sqlalchemy_exasol.websocket import EXADialect_websocket
 
-    try:
-        assert isinstance(engine.dialect, EXADialect_websocket)
-    finally:
-        engine.dispose()
+assert {entry_point_name!r} not in registry.impls
+engine = create_engine({url!r})
+try:
+    assert type(engine.dialect) is EXADialect_websocket
+finally:
+    engine.dispose()
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Fixes #801.

The released bare `exa` entry point resolves to the legacy `sqlalchemy_exasol.base` module. SQLAlchemy's `create_engine()` path hides this through its legacy `module.dialect` fallback, but direct entry-point consumers do not use that fallback. In particular, Superset loads the entry point and reads class attributes such as `.name`, so the module-valued entry point crashes there.

This changes the canonical target to `sqlalchemy_exasol.websocket:EXADialect_websocket`, matching `exa.websocket`. It preserves existing `create_engine("exa://...")` and `create_engine("exa+websocket://...")` behavior while repairing consumers that call `EntryPoint.load()` directly.

## Tests

- `python -m pytest -q test/unit/exasol/test_entry_points.py` — 6 passed
- `python -m pytest -q test/unit` — 70 passed
- `python -m build` — sdist and wheel built successfully; wheel metadata verified with both entry-point names targeting `EXADialect_websocket`
- Regression coverage checks installed distribution discovery, Superset's direct-load shape, the runtime default, and both engine URL forms without connecting
- CI will exercise the repository's supported Python 3.10–3.14 matrix

No live Exasol instance was available, so live integration suites were not run. The change only affects distribution entry-point metadata; the engine tests deliberately instantiate and dispose engines without opening a database connection.

# Checklist

## For any Pull Request

- [x] the title of the Pull Request?
- [x] the title of the corresponding issue?
- [x] there are no other open Pull Requests for the same update/change?
- [x] that the issue which this Pull Request fixes ("Fixes...") is mentioned?

## When Changes Were Made

- [x] update the changelog?
- [x] update the implementation?
- [x] check coverage and add tests: unit tests and, if relevant, integration tests?
- [ ] update the User Guide & other documentation? (Not applicable: no user-facing API change.)
- [ ] resolve any failing CI criteria (incl. Sonar quality gate)? (Pending CI.)
